### PR TITLE
Fix base directory retrieval for read_corpus method.

### DIFF
--- a/cpu_rec.py
+++ b/cpu_rec.py
@@ -263,7 +263,7 @@ class TrainingData(object):
         return data
     def read_corpus(self):
         """ Gets the raw training dataset """
-        basedir = os.path.dirname(__file__)
+        basedir = os.path.dirname(os.path.realpath(__file__))
         if basedir != '': basedir += '/'
         # If the default training set has been installed along cpu_rec.py,
         # we use it.


### PR DESCRIPTION
Hello,

I propose the following fix in order to be able to clone the cpu_rec repository and use cpu_rec.py with symbolic link, than copy the corpus and the script. Without this fix, the following problem exist with symbolic link.

```text
$ cd /tmp
$ git clone https://github.com/airbus-seclab/cpu_rec.git
$ ln -s /tmp/cpu_rec/cpu_rec.py /usr/local/bin/cpu_rec.py
$ cd ~
$ cpu_rec.py 
ERROR: No corpus available
```


